### PR TITLE
3.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the library will be documented in this file.
 The format of the file is based on [Keep a Changelog](http://keepachangelog.com/)
 and this library adheres to [Semantic Versioning](http://semver.org/) as mentioned in [README.md][readme] file.
 
+## [ [3.1.1](https://github.com/infobip/infobip-api-go-client/releases/tag/3.1.1)] - 2025-04-28
+
+## Added
+* `AdditionalProperties map[string]interface{}` to the `TemplateTextBody` struct to align with the current state of the API.
+* `AdditionalProperties map[string]interface{}` to the `TemplateTextHeader` struct to align with the current state of the API.
+
+## Changed
+*  **Renamed Field**: `body` ➜ `requestBody` in `ApiSubmitFormDataRequest` (`FormsApi`) struct to improve clarity and naming consistency.
+*  **Fixed Incorrect Field Type**: Updated `Data` field type from `map[string]map[string]interface{}` to `map[string]interface{}` to align with the current state of the API.
+
 ## [ [3.1.0](https://github.com/infobip/infobip-api-go-client/releases/tag/3.1.0)] - 2025-01-20
 
 ⚠️ IMPORTANT NOTE: This release contains compile time breaking changes.

--- a/moments.md
+++ b/moments.md
@@ -127,6 +127,6 @@ To submit data to a specific form, you can use the following code:
     response, _, err := infobipClient.
         FormsAPI.
         SubmitFormData(context.Background(), formId).
-        Body(formDataRequest).
+        RequestBody(formDataRequest).
         Execute()
 ````

--- a/pkg/infobip/api/forms_api.go
+++ b/pkg/infobip/api/forms_api.go
@@ -559,14 +559,14 @@ type ApiSubmitFormDataRequest struct {
 	ctx                      context.Context
 	ApiService               *FormsAPIService
 	id                       string
-	body                     *map[string]interface{}
+	requestBody              *map[string]interface{}
 	ibSubmissionSource       *string
 	ibSubmissionFormCampaign *string
 }
 
 // Form Data
-func (r ApiSubmitFormDataRequest) Body(body map[string]interface{}) ApiSubmitFormDataRequest {
-	r.body = &body
+func (r ApiSubmitFormDataRequest) RequestBody(requestBody map[string]interface{}) ApiSubmitFormDataRequest {
+	r.requestBody = &requestBody
 	return r
 }
 
@@ -625,8 +625,8 @@ func (a *FormsAPIService) SubmitFormDataExecute(r ApiSubmitFormDataRequest) (*Fo
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.body == nil {
-		return localVarReturnValue, nil, reportError("body is required and must be specified")
+	if r.requestBody == nil {
+		return localVarReturnValue, nil, reportError("requestBody is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -653,7 +653,7 @@ func (a *FormsAPIService) SubmitFormDataExecute(r ApiSubmitFormDataRequest) (*Fo
 		parameterAddToHeaderOrQuery(localVarHeaderParams, "ib-submission-form-campaign", r.ibSubmissionFormCampaign, "simple", "")
 	}
 	// body params
-	localVarPostBody = r.body
+	localVarPostBody = r.requestBody
 	if r.ctx != nil {
 		// API Key Authentication
 		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {

--- a/pkg/infobip/configuration.go
+++ b/pkg/infobip/configuration.go
@@ -82,7 +82,7 @@ type Configuration struct {
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
 		DefaultHeader: make(map[string]string),
-		UserAgent:     "infobip-api-client-go/3.1.0",
+		UserAgent:     "infobip-api-client-go/3.1.1",
 		Debug:         false,
 		Scheme:        "https",
 		Servers: ServerConfigurations{

--- a/pkg/infobip/infobip.go
+++ b/pkg/infobip/infobip.go
@@ -10,4 +10,4 @@ Contact: support@infobip.com
 
 package infobip
 
-const Version = "3.1.0"
+const Version = "3.1.1"

--- a/pkg/infobip/models/messagesapi/template_flow_button.go
+++ b/pkg/infobip/models/messagesapi/template_flow_button.go
@@ -25,7 +25,7 @@ type TemplateFlowButton struct {
 	// Flow token.
 	Token *string
 	// Message action payload data. JSON object with the data payload for the first screen
-	Data map[string]map[string]interface{}
+	Data map[string]interface{}
 }
 
 type _TemplateFlowButton TemplateFlowButton
@@ -82,9 +82,9 @@ func (o *TemplateFlowButton) SetToken(v string) {
 }
 
 // GetData returns the Data field value if set, zero value otherwise.
-func (o *TemplateFlowButton) GetData() map[string]map[string]interface{} {
+func (o *TemplateFlowButton) GetData() map[string]interface{} {
 	if o == nil || IsNil(o.Data) {
-		var ret map[string]map[string]interface{}
+		var ret map[string]interface{}
 		return ret
 	}
 	return o.Data
@@ -92,9 +92,9 @@ func (o *TemplateFlowButton) GetData() map[string]map[string]interface{} {
 
 // GetDataOk returns a tuple with the Data field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TemplateFlowButton) GetDataOk() (map[string]map[string]interface{}, bool) {
+func (o *TemplateFlowButton) GetDataOk() (map[string]interface{}, bool) {
 	if o == nil || IsNil(o.Data) {
-		return map[string]map[string]interface{}{}, false
+		return map[string]interface{}{}, false
 	}
 	return o.Data, true
 }
@@ -108,8 +108,8 @@ func (o *TemplateFlowButton) HasData() bool {
 	return false
 }
 
-// SetData gets a reference to the given map[string]map[string]interface{} and assigns it to the Data field.
-func (o *TemplateFlowButton) SetData(v map[string]map[string]interface{}) {
+// SetData gets a reference to the given map[string]interface{} and assigns it to the Data field.
+func (o *TemplateFlowButton) SetData(v map[string]interface{}) {
 	o.Data = v
 }
 

--- a/pkg/infobip/models/messagesapi/template_text_body.go
+++ b/pkg/infobip/models/messagesapi/template_text_body.go
@@ -21,7 +21,8 @@ var _ MappedNullable = &TemplateTextBody{}
 
 // TemplateTextBody Key value pairs that will be replaced during message sending. Valid example `{\"1\": \"John\", \"2\": \"Smith\", \"type\": \"TEXT\"}`.
 type TemplateTextBody struct {
-	Type TemplateBodyType
+	Type                 TemplateBodyType
+	AdditionalProperties map[string]interface{}
 }
 
 type _TemplateTextBody TemplateTextBody
@@ -33,6 +34,7 @@ type _TemplateTextBody TemplateTextBody
 func NewTemplateTextBody() *TemplateTextBody {
 	this := TemplateTextBody{}
 	this.Type = "TEXT"
+	this.AdditionalProperties = make(map[string]interface{})
 	return &this
 }
 
@@ -42,6 +44,7 @@ func NewTemplateTextBody() *TemplateTextBody {
 func NewTemplateTextBodyWithDefaults() *TemplateTextBody {
 	this := TemplateTextBody{}
 	this.Type = "TEXT"
+	this.AdditionalProperties = make(map[string]interface{})
 	return &this
 }
 
@@ -56,6 +59,11 @@ func (o TemplateTextBody) MarshalJSON() ([]byte, error) {
 func (o TemplateTextBody) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["type"] = o.Type
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 

--- a/pkg/infobip/models/messagesapi/template_text_header.go
+++ b/pkg/infobip/models/messagesapi/template_text_header.go
@@ -21,7 +21,8 @@ var _ MappedNullable = &TemplateTextHeader{}
 
 // TemplateTextHeader Key value pairs that will be replaced during message sending in a header. Valid example `{\"1\": \"John\", \"2\": \"Smith\", \"type\": \"TEXT\"}`
 type TemplateTextHeader struct {
-	Type TemplateHeaderType
+	Type                 TemplateHeaderType
+	AdditionalProperties map[string]interface{}
 }
 
 type _TemplateTextHeader TemplateTextHeader
@@ -33,6 +34,7 @@ type _TemplateTextHeader TemplateTextHeader
 func NewTemplateTextHeader() *TemplateTextHeader {
 	this := TemplateTextHeader{}
 	this.Type = "TEXT"
+	this.AdditionalProperties = make(map[string]interface{})
 	return &this
 }
 
@@ -42,6 +44,7 @@ func NewTemplateTextHeader() *TemplateTextHeader {
 func NewTemplateTextHeaderWithDefaults() *TemplateTextHeader {
 	this := TemplateTextHeader{}
 	this.Type = "TEXT"
+	this.AdditionalProperties = make(map[string]interface{})
 	return &this
 }
 
@@ -56,6 +59,11 @@ func (o TemplateTextHeader) MarshalJSON() ([]byte, error) {
 func (o TemplateTextHeader) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["type"] = o.Type
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 

--- a/tests/forms_api_test.go
+++ b/tests/forms_api_test.go
@@ -217,16 +217,16 @@ func TestShouldSubmitFormData(t *testing.T) {
 	givenStatus := "OK"
 
 	givenResponse := fmt.Sprintf(`{
-        "status": "%s"
-    }`, givenStatus)
+       "status": "%s"
+   }`, givenStatus)
 
 	givenNumber := 26
 	givenBoolean := true
 
 	requestBody := fmt.Sprintf(`{
-        "number": %d,
-        "boolean": %t
-    }`, givenNumber, givenBoolean)
+       "number": %d,
+       "boolean": %t
+   }`, givenNumber, givenBoolean)
 
 	formDataRequest := map[string]interface{}{
 		"number":  givenNumber,
@@ -243,7 +243,7 @@ func TestShouldSubmitFormData(t *testing.T) {
 	response, _, err := infobipClient.
 		FormsAPI.
 		SubmitFormData(context.Background(), formId).
-		Body(formDataRequest).
+		RequestBody(formDataRequest).
 		Execute()
 
 	assert.Nil(t, err)


### PR DESCRIPTION
## Added
* `AdditionalProperties map[string]interface{}` to the `TemplateTextBody` struct to align with the current state of the API.
* `AdditionalProperties map[string]interface{}` to the `TemplateTextHeader` struct to align with the current state of the API.

## Changed
*  **Renamed Field**: `body` ➜ `requestBody` in `ApiSubmitFormDataRequest` (`FormsApi`) struct to improve clarity and naming consistency.
*  **Fixed Incorrect Field Type**: Updated `Data` field type from `map[string]map[string]interface{}` to `map[string]interface{}` to align with the current state of the API.